### PR TITLE
Fix/revert back order logic

### DIFF
--- a/apps/order/mutations.py
+++ b/apps/order/mutations.py
@@ -62,23 +62,14 @@ class DeleteCartItem(CartItemMixin, DeleteMutation):
     result = graphene.Field(CartItemType)
 
 
-PlaceOrderFromCartInputType = generate_input_type_for_serializer(
-    'PlaceOrderFromCartInputType',
-    serializer_class=CreateOrderFromCartSerializer
-)
-
-
 class PlaceOrderFromCart(graphene.Mutation):
-    class Arguments:
-        data = PlaceOrderFromCartInputType(required=True)
-
     errors = graphene.List(graphene.NonNull(CustomErrorType))
     ok = graphene.Boolean()
     result = graphene.Field(OrderType)
 
     @staticmethod
-    def mutate(root, info, data):
-        serializer = CreateOrderFromCartSerializer(data=data, context={'request': info.context.request})
+    def mutate(root, info):
+        serializer = CreateOrderFromCartSerializer(data=dict(), context={'request': info.context.request})
         if errors := mutation_is_not_valid(serializer):
             return PlaceOrderFromCart(errors=errors, ok=False)
         instance = serializer.save()

--- a/apps/order/schema.py
+++ b/apps/order/schema.py
@@ -41,6 +41,7 @@ class CartItemType(DjangoObjectType):
 
 class CartGrandTotalType(graphene.ObjectType):
     grand_total_price = graphene.Int()
+    total_quantity = graphene.Int()
 
     class Meta:
         fields = (
@@ -50,6 +51,10 @@ class CartGrandTotalType(graphene.ObjectType):
     @staticmethod
     def resolve_grand_total_price(root, info, **kwargs) -> QuerySet:
         return get_cart_items_qs(info).aggregate(Sum('total_price'))['total_price__sum']
+
+    @staticmethod
+    def resolve_total_quantity(root, info, **kwargs):
+        return get_cart_items_qs(info).aggregate(Sum('quantity'))['quantity__sum']
 
 
 class CartType(CustomDjangoListObjectType, CartGrandTotalType):

--- a/apps/order/serializers.py
+++ b/apps/order/serializers.py
@@ -62,7 +62,7 @@ class CreateOrderFromCartSerializer(CreatedUpdatedBaseSerializer, serializers.Mo
 
         # Remove books form withlist
         book_ids = CartItem.objects.filter(created_by=self.context['request'].user).values_list('book', flat=True)
-        WishList.objects.filter(book_id__in=list(book_ids)).delete()
+        WishList.objects.filter(book_id__in=book_ids).delete()
 
         # Clear cart
         cart_items.delete()

--- a/apps/order/tests/test_orders.py
+++ b/apps/order/tests/test_orders.py
@@ -8,8 +8,8 @@ from apps.publisher.factories import PublisherFactory
 class TestOrder(GraphQLTestCase):
     def setUp(self):
         self.place_order_from_cart = '''
-            mutation Mutation($input: PlaceOrderFromCartInputType!) {
-                placeOrderFromCart(data: $input) {
+            mutation Mutation {
+                placeOrderFromCart {
                     ok
                     errors
                 }
@@ -95,8 +95,7 @@ class TestOrder(GraphQLTestCase):
         self.assertEqual(len(result), 2)
 
         # Place order
-        minput = {'cartItemIds': [self.cart_item_1.id, self.cart_item_2.id]}
-        self.query_check(self.place_order_from_cart, minput=minput, okay=True)
+        self.query_check(self.place_order_from_cart, okay=True)
 
         # Test should clear cart after order placed
         content = self.query_check(self.cart)

--- a/schema.graphql
+++ b/schema.graphql
@@ -205,6 +205,7 @@ type CartType {
   page: Int
   pageSize: Int
   grandTotalPrice: Int
+  totalQuantity: Int
 }
 
 type CategoryListType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -516,7 +516,7 @@ type Mutation {
   createCartItem(data: CartItemInputType!): CreateCartItem
   updateCartItem(data: CartItemInputType!, id: ID!): UpdateCartItem
   deleteCartItem(id: ID!): DeleteCartItem
-  placeOrderFromCart(data: PlaceOrderFromCartInputType!): PlaceOrderFromCart
+  placeOrderFromCart: PlaceOrderFromCart
   placeSingleOrder(data: PlaceSingleOrderInputType!): PlaceSingleOrder
   updateOrder(data: OrderUpdateInputType!, id: ID!): UpdateOrder
   deleteOrder(id: ID!): DeleteOrder
@@ -602,10 +602,6 @@ type PlaceOrderFromCart {
   errors: [GenericScalar!]
   ok: Boolean
   result: OrderType
-}
-
-input PlaceOrderFromCartInputType {
-  cartItemIds: [ID!]
 }
 
 type PlaceSingleOrder {


### PR DESCRIPTION
## Changes

* Revert back order logic, remove cart_ids from serializer
* Add total quantity in cart

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
