### PR TITLE
Use same enum (BookGradeEnum) in mutation and query.

### DIFF
--- a/apps/book/schema.py
+++ b/apps/book/schema.py
@@ -8,6 +8,7 @@ from utils.graphene.fields import DjangoPaginatedListObjectField
 
 from apps.book.models import Book, Tag, Category, Author, WishList
 from apps.book.filters import BookFilter, TagFilter, CategoryFilter, AuthorFilter
+from apps.book.enums import BookGradeEnum
 from apps.order.schema import CartItemType
 
 
@@ -60,6 +61,7 @@ class AuthorListType(CustomDjangoListObjectType):
 class BookType(DjangoObjectType):
     wishlist_id = graphene.ID()
     cart_details = graphene.Field(CartItemType)
+    grade = graphene.Field(BookGradeEnum)
 
     class Meta:
         model = Book

--- a/config/enums.py
+++ b/config/enums.py
@@ -1,0 +1,5 @@
+from apps.book.enums import enum_map as book_enum_map
+
+ENUM_TO_GRAPHENE_ENUM_MAP = {
+    **book_enum_map,
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -156,7 +156,7 @@ input BookCreateInputType {
   weight: Int
   publishedDate: Date!
   edition: String
-  grade: grade
+  grade: BookGradeEnum
   isPublished: Boolean
   price: Int!
   metaTitle: String
@@ -202,7 +202,7 @@ type BookDetailType {
   publishedDate: Date!
   edition: String
   publisher: PublisherType!
-  grade: BookGrade
+  grade: BookGradeEnum
   isPublished: Boolean!
   price: Int!
   metaTitle: String
@@ -237,12 +237,6 @@ type BookDetailType {
   bookOrderCartItem: [BookOrderType!]!
   wishlistId: ID
   cartDetails: CartItemType
-}
-
-enum BookGrade {
-  GRADE_ONE
-  GRADE_TWO
-  GRADE_THREE
 }
 
 enum BookGradeEnum {
@@ -301,7 +295,7 @@ type BookType {
   publishedDate: Date!
   edition: String
   publisher: PublisherType!
-  grade: BookGrade
+  grade: BookGradeEnum
   isPublished: Boolean!
   price: Int!
   metaTitle: String
@@ -1267,12 +1261,6 @@ enum blog_publish_type {
 enum faq_publish_type {
   PUBLISH
   DRAFT
-}
-
-enum grade {
-  GRADE_ONE
-  GRADE_TWO
-  GRADE_THREE
 }
 
 enum language {


### PR DESCRIPTION
- Setup mutation enum registor.

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
