### PR TITLE
Fix locale translation in graphql

### DIFF
--- a/apps/book/tests/test_enum_translations.py
+++ b/apps/book/tests/test_enum_translations.py
@@ -1,0 +1,36 @@
+from utils.graphene.tests import GraphQLTestCase
+from apps.publisher.factories import PublisherFactory
+from apps.book.factories import BookFactory
+
+
+class TestBookEnumTranslation(GraphQLTestCase):
+    def setUp(self):
+        self.book_query = '''
+            query GradeOptions {
+              gradeList: __type(name: "BookGradeEnum") {
+                enumValues {
+                  name
+                  description
+                }
+              }
+            }
+        '''
+        super().setUp()
+
+    def test_should_translate_book_enums(self):
+        publisher = PublisherFactory.create()
+        district = BookFactory.create(publisher=publisher)
+
+        response = self.query_check(
+            self.book_query,
+            variables={'id': district.id},
+            headers={'HTTP_ACCEPT_LANGUAGE': 'ne'}
+        )
+        self.assertEqual(response['data']['gradeList']['enumValues'][0]['description'], 'ग्रेड १')
+
+        response = self.query_check(
+            self.book_query,
+            variables={'id': district.id},
+            headers={'HTTP_ACCEPT_LANGUAGE': 'en'}
+        )
+        self.assertEqual(response['data']['gradeList']['enumValues'][0]['description'], 'Grade 1')

--- a/utils/graphene/enums.py
+++ b/utils/graphene/enums.py
@@ -11,7 +11,7 @@ from utils.common import to_camelcase
 
 def enum_description(v: enum.Enum) -> Union[str, None]:
     try:
-        return str(v.label)
+        return v.label
     except AttributeError:
         return None
 


### PR DESCRIPTION
## Changes

* Fix locale translation in graphql
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
